### PR TITLE
Fix project tree in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,17 @@ Ce dépôt contient les instructions de construction de mon portfolio personnel.
 
 ## Arborescence du projet
 
+Le dépôt contient actuellement les fichiers et dossiers suivants :
+
+```
 .
 ├── docs/
-│ ├── images/
-│ ├── Home.md
-│ ├── Experience.md
-│ ├── Project.md
-│ ├── About.md
-│ ├── Contact.md
-│ ├── Tools.md
-│ └── CV-M2R.pdf
-├── public/
+│   ├── images/
+│   └── CV-M2R.pdf
 └── README.md
+```
+
+Les pages `Home.md`, `Experience.md`, `Project.md`, `About.md`, `Contact.md` et `Tools.md` devront être ajoutées ultérieurement pour compléter le site.
 
 ---
 


### PR DESCRIPTION
## Summary
- update README to describe the files that are actually present
- note that Markdown pages still need to be created
- remove mention of a `public` directory that doesn't exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7446977c832683cea4e6c96f8059